### PR TITLE
Url fix

### DIFF
--- a/OrbitOne.BuildScreen/OrbitOne.BuildScreen.Services.Tfs/TfsHelperClass.cs
+++ b/OrbitOne.BuildScreen/OrbitOne.BuildScreen.Services.Tfs/TfsHelperClass.cs
@@ -35,17 +35,7 @@ namespace OrbitOne.BuildScreen.Services.Tfs
         }
         public string GetReportUrl(string tpc, string tp, string buildUri)
         {
-            var basic = "";
-            if (tpc.Contains("https"))
-            {
-                basic = tpc;
-            }
-            else
-            {
-                basic = "https://" + tpc.Replace("\\", "/tfs/");
-            }
-            
-            return basic + "/" + tp + SummaryString + buildUri;
+            return tpc + "/" + tp + SummaryString + buildUri;
         }
     }
 }

--- a/OrbitOne.BuildScreen/OrbitOne.BuildScreen.Services.Tfs/TfsService.cs
+++ b/OrbitOne.BuildScreen/OrbitOne.BuildScreen.Services.Tfs/TfsService.cs
@@ -146,7 +146,7 @@ namespace OrbitOne.BuildScreen.Services.Tfs
                         TeamProjectCollection = teamProjectCollection.Name,
                         TotalNumberOfTests = 0,
                         Id = "TFS" + teamProjectNode.Resource.Identifier + def.Id,
-                        BuildReportUrl = _helperClass.GetReportUrl(teamProjectCollection.Name, teamProjectNode.Resource.DisplayName, build.Uri.OriginalString)
+                        BuildReportUrl = _helperClass.GetReportUrl(teamProjectCollection.Uri.ToString(), teamProjectNode.Resource.DisplayName, build.Uri.OriginalString)
                     };
                     //Retrieve testruns
                     var testResults = GetTestResults(teamProjectNode, testService, build);

--- a/OrbitOne.BuildScreen/OrbitOne.BuildScreen/Scripts/App/Views/Configuration.html
+++ b/OrbitOne.BuildScreen/OrbitOne.BuildScreen/Scripts/App/Views/Configuration.html
@@ -79,7 +79,7 @@
         </fieldset>
 
         <fieldset class="form-fieldset ui-input">
-            <input type="url" name="vsoUrl" id="vso-url" ng-pattern="/^(https:\/\/)([\da-z\.-]+)\.(visualstudio.com)$/" data-ng-model="newVsoConfig.Uri" tabindex="0" ng-blur="onBlur($event)" required />
+            <input type="url" name="vsoUrl" id="vso-url" ng-pattern="/^(https:\/\/)([\da-z\.\-]+)\.(visualstudio.com)$/" data-ng-model="newVsoConfig.Uri" tabindex="0" ng-blur="onBlur($event)" required />
             <label for="vso-url">
                 <span data-text="VSO URL">VSO URL</span>
                 <span data-text="is not a valid url" ng-show="vsoForm.vsoUrl.$invalid && !vsoForm.vsoUrl.$pristine"> is not a valid url</span>
@@ -123,7 +123,7 @@
         </fieldset>
 
         <fieldset class="form-fieldset ui-input">
-            <input type="url" name="tfsUrl" id="tfs-url" ng-pattern="/^(https?:\/\/)([\da-z\.-:]+)(\/tfs)$/" data-ng-model="newTfsConfig.Uri" tabindex="0" ng-blur="onBlur($event)" required/>
+            <input type="url" name="tfsUrl" id="tfs-url" ng-pattern="/^(https?:\/\/)([\da-z\.\-:]+)(\/tfs)$/" data-ng-model="newTfsConfig.Uri" tabindex="0" ng-blur="onBlur($event)" required/>
             <label for="tfs-url">
                 <span data-text="TFS URL">TFS URL</span>
                 <span data-text="is not a valid URL" ng-show="tfsForm.tfsUrl.$invalid && !tfsForm.tfsUrl.$pristine"> is not a valid URL</span>


### PR DESCRIPTION
Fixes two issue related to tfs urls.
. The url validation of an on-premise TFS did not allow dashes '.', e-g- https://my-tfs.example.com
. The report URL for an on-premise url is wrong when a custom port is used,  e.g. with configured url https://my-tfs.example.com:8443/tfs the report url was wrongly generated as https://my-tfs.example.com/tfs/defaultcollection/...
