### PR TITLE
Performance optimization

### DIFF
--- a/OrbitOne.BuildScreen/OrbitOne.BuildScreen.Services.Tfs/TfsService.cs
+++ b/OrbitOne.BuildScreen/OrbitOne.BuildScreen.Services.Tfs/TfsService.cs
@@ -185,6 +185,8 @@ namespace OrbitOne.BuildScreen.Services.Tfs
                 buildDetailSpec.MaxBuildsPerDefinition = 1;
                 buildDetailSpec.QueryOrder = BuildQueryOrder.FinishTimeDescending;
                 buildDetailSpec.MinFinishTime = filterDate;
+                buildDetailSpec.InformationTypes = null;
+                buildDetailSpec.QueryOptions = QueryOptions.Definitions | QueryOptions.BatchedRequests;
 
                 build = buildServer.QueryBuilds(buildDetailSpec).Builds.FirstOrDefault();
             }
@@ -207,6 +209,8 @@ namespace OrbitOne.BuildScreen.Services.Tfs
                 inProgressBuildDetailSpec.Status = BuildStatus.Succeeded;
                 inProgressBuildDetailSpec.MaxBuildsPerDefinition = 1;
                 inProgressBuildDetailSpec.QueryOrder = BuildQueryOrder.FinishTimeDescending;
+                inProgressBuildDetailSpec.InformationTypes = null;
+                inProgressBuildDetailSpec.QueryOptions = QueryOptions.None;
 
                 var lastSuccesfulBuild = buildServer.QueryBuilds(inProgressBuildDetailSpec).Builds.FirstOrDefault();
 


### PR DESCRIPTION
The TFS API for querying build information was slowing TFS down because
of the performance impact. I investigated this issue 2 years ago when i
made my own build monitor. By specifying the InformationTypes and
QueryOptions to the minimum needed, the load on the TFS server can be
reduced dramatically.

Note: as far as I've tested, all functionality remains the same with this fix. Of there is any information about builds or definition missing in the tfs query result, this can be further tweaked by changing the QueryOptions.
