### PR TITLE
call REST API using only build ID and not build URI

### DIFF
--- a/OrbitOne.BuildScreen/OrbitOne.BuildScreen.RestApiService/VsoHelperClass.cs
+++ b/OrbitOne.BuildScreen/OrbitOne.BuildScreen.RestApiService/VsoHelperClass.cs
@@ -55,7 +55,11 @@ namespace OrbitOne.BuildScreen.RestApiService
                             await response.Content.ReadAsStringAsync();
                         objects =
                             JsonConvert.DeserializeObject<JsonWrapper<T>>(jsonstr).Value;
-                    } 
+                    }
+                    else
+                    {
+                        LogService.WriteInfo(string.Format("Invalid request {0}: status {1}", formattedUrl, response.StatusCode));
+                    }
                 }
             }
             catch (AggregateException e)
@@ -83,10 +87,10 @@ namespace OrbitOne.BuildScreen.RestApiService
             var urlpart = (summary) ? SummaryString : LogString;
 
             var firstPart = _config.Uri + "/DefaultCollection/" + teamProjectName + urlpart;
-            
+
             var lastIndexOf = buildUri.LastIndexOf("/");
             var number = "";
-           
+
             try
             {
                 if (lastIndexOf != -1)
@@ -99,7 +103,7 @@ namespace OrbitOne.BuildScreen.RestApiService
             {
                 LogService.WriteError(ex);
             }
-           
+
 
             return firstPart + number;
         }

--- a/OrbitOne.BuildScreen/OrbitOne.BuildScreen.RestApiService/VsoRestService.cs
+++ b/OrbitOne.BuildScreen/OrbitOne.BuildScreen.RestApiService/VsoRestService.cs
@@ -79,7 +79,7 @@ namespace OrbitOne.BuildScreen.RestApiService
                         Id = "VSO" + teamProjectId + build.Definition.Id
                     };
 
-                    if(buildInfoDto.RequestedByName.StartsWith("[DefaultCollection]"))
+                    if (buildInfoDto.RequestedByName.StartsWith("[DefaultCollection]"))
                     {
                         buildInfoDto.RequestedByName = "Service Account";
                     }
@@ -147,12 +147,18 @@ namespace OrbitOne.BuildScreen.RestApiService
             Build secondLastBuild = null;
             try
             {
-                secondLastBuild = _helperClass.RetrieveTask<Build>(String.Format(_configurationRestService.RetrieveLastSuccessfulBuildUrl, teamProjectName,
-                String.Format(_configurationRestService.BuildDefinitionUri, build.Definition.Id))).Result.FirstOrDefault()
+                secondLastBuild = _helperClass.RetrieveTask<Build>(
+                    String.Format(
+                        _configurationRestService.RetrieveLastSuccessfulBuildUrl,
+                        teamProjectName,
+                        build.Definition.Id)
+                        ).Result.FirstOrDefault()
                   ??
                   _helperClass.RetrieveTask<Build>(
-                      String.Format(_configurationRestService.RetriveLastPartiallyOrFailedUrl, teamProjectName,
-                          String.Format(_configurationRestService.BuildDefinitionUri, build.Definition.Id)))
+                      String.Format(
+                          _configurationRestService.RetriveLastPartiallyOrFailedUrl,
+                          teamProjectName,
+                          build.Definition.Id))
                       .Result.FirstOrDefault();
             }
             catch (Exception e)
@@ -263,7 +269,7 @@ namespace OrbitOne.BuildScreen.RestApiService
                     buildInfoDto.Status = StatusEnum.Statuses.inProgress.ToString();
                     var secondLastBuildList =
                          _helperClass.RetrieveTask<Build>(
-                        (String.Format(_configurationRestService.RetrieveLastSuccessfulBuildUrl, teamProjectName, bdUri))).Result;
+                        (String.Format(_configurationRestService.RetrieveLastSuccessfulBuildUrl, teamProjectName, bdId))).Result;
 
                     var secondLastBuild = secondLastBuildList.FirstOrDefault();
                     if (secondLastBuild != null)


### PR DESCRIPTION
There was an error while calling the VSTS REST API. The REST API expects the value of the “definitions” parameter to be a list of definition IDs, not URIs.
So the call to 
/DefaultCollection/JJJJ/_apis/build/builds?api-version=2.0&definitions=vstfs:///Build/Definition/ID&resultFilter=succeeded&$top=1
should be:
/DefaultCollection/JJJJ/_apis/build/builds?api-version=2.0&definitions=ID&resultFilter=succeeded&$top=1
